### PR TITLE
Adds pre-commit-hook.yml

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,9 @@
+# Allows gitlab-ci-linter to be used as a pre-commit-hook with pre-commit
+# https://pre-commit.com/#pre-commit-configyaml---hooks
+- id: gitlab-ci-linter
+  name: gitlab ci linter
+  description: Check the .gitlab-ci.yml for valid syntax
+  entry: gitlab-ci-linter
+  language: golang
+  types: [yaml]
+  files: .gitlab-ci.yml$


### PR DESCRIPTION
I've added support for using gitlab-ci-linter as a pre-commit-hook in the `pre-commit` project https://pre-commit.com/

Once you have merged this pull request, anyone can include your tool in their `.pre-commit-config.yaml` like this:
```
  - repo: git@github.com:cryptobanana/gitlab-ci-linter.git                                                                                                                                                         
    rev: v1.0                                                                                                                                                                                                      
    hooks:                                                                                                                                                                                                         
      - id: gitlab-ci-linter                                                                                                                                                                                       
        name: gitlab-ci-linter                                                                                                                                                                                     
        entry: gitlab-ci-linter                                                                                                                                                                                    
        language: golang                                                                                                                                                                                           
        types: [yaml]                                                                                                                                                                                              
```