### PR TITLE
feat: add dry-run parameter when lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Guess project path, and use it in the API URL.
 - Added a `--project-path` option
 - Added a `--merged-yaml` option to allow merged yaml to be returned in response from gitlab API
+- Added a `--dry-run` option to run pipeline creation simulation
+- Added a `--dry-run-ref` option to choose trigger ref when dry run
 - Improve Gitlab API HTTP error code handling
 - Publish release on Cloudsmith
 - Build and publish a Docker image on Docker Hub

--- a/git.go
+++ b/git.go
@@ -23,6 +23,7 @@ package main
 import (
 	"errors"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"regexp"
@@ -107,4 +108,14 @@ func parseGitRemoteURL(remoteURL string) (string, string) {
 	}
 
 	return "", ""
+}
+
+// GetCurrentBranch returns the current branch name of the git repository
+func GetCurrentBranch() (string, error) {
+	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(output)), nil
 }

--- a/gitlab.go
+++ b/gitlab.go
@@ -50,6 +50,8 @@ const gitlabAPICiLintPath = "/ci/lint"
 // GitlabAPILintRequest struct represents the JSON body of a request sent to the Gitlab API /ci/lint
 type GitlabAPILintRequest struct {
 	Content string `json:"content"`
+	DryRun  bool   `json:"dry_run"`
+	Ref     string `json:"ref"`
 }
 
 // GitlabAPILintResponse struct represents the JSON body of a response from the Gitlab API /ci/lint
@@ -189,7 +191,14 @@ func lintGitlabCIUsingAPI(lintURL string, ciFileContent string) (status bool, ms
 	// {
 	//   "content": "<ESCAPED CONTENT OF THE GITLAB-CI FILE>"
 	// }
-	var reqParams = GitlabAPILintRequest{Content: ciFileContent}
+	if dryRunRef == "" {
+		dryRunRef, _ = GetCurrentBranch()
+	}
+	var reqParams = GitlabAPILintRequest{
+		Content: ciFileContent,
+		DryRun:  dryRun,
+		Ref:     dryRunRef,
+	}
 	reqBody, _ := json.Marshal(reqParams)
 
 	// Prepare requesting the API

--- a/main.go
+++ b/main.go
@@ -73,6 +73,12 @@ var verboseMode = false
 // Tells if the response should include the merged yaml from the Gitlab API
 var includeMergedYaml = false
 
+// Tells if run pipeline creation simulation
+var dryRun = false
+
+// When dry_run is true, sets the branch or tag context to use to validate the CI/CD YAML configuration. Defaults to the project’s default branch when not set.
+var dryRunRef string
+
 // Analyse a PATH argument, that can be a directory or file, to use it as a gitlab-ci file a a directory
 // where to start searching
 func processPathArgument(path string) {
@@ -236,6 +242,19 @@ Usage:
 			Usage:       "include merged yaml in response",
 			EnvVars:     []string{"GCL_INCLUDE_MERGED_YAML"},
 			Destination: &includeMergedYaml,
+		},
+		&cli.BoolFlag{
+			Name:        "dry-run",
+			Aliases:     []string{"s"},
+			Usage:       "run pipeline creation simulation",
+			EnvVars:     []string{"GCL_DRY_RUN"},
+			Destination: &dryRun,
+		},
+		&cli.StringFlag{
+			Name:        "dry-run-ref",
+			Usage:       "When dry_run is true, sets the branch or tag to validate ci yml",
+			EnvVars:     []string{"GCL_DRY_RUN_REF"},
+			Destination: &dryRunRef,
 		},
 	}
 	cli.VersionFlag = &cli.BoolFlag{


### PR DESCRIPTION
check `rules` `only` `except` and `needs` job dependencies

ref: 
https://docs.gitlab.com/ee/api/lint.html
https://docs.gitlab.com/ee/ci/yaml/lint.html#simulate-a-pipeline